### PR TITLE
fix: hacky transparent background fix

### DIFF
--- a/png_encode/Cargo.lock
+++ b/png_encode/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -61,20 +61,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
@@ -106,9 +96,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -123,7 +113,6 @@ version = "0.1.0"
 dependencies = [
  "png",
  "wasm-bindgen",
- "web-sys",
  "wee_alloc",
 ]
 
@@ -230,16 +219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/png_encode/Cargo.toml
+++ b/png_encode/Cargo.toml
@@ -1,4 +1,3 @@
-cargo-features = ["profile-rustflags", "trim-paths"]
 
 [package]
 name = "png_encode"
@@ -9,9 +8,8 @@ edition = "2024"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-png = "0.17.16"
-wasm-bindgen = "0.2.100"
-web-sys = "0.3.77"
+png = "0.18"
+wasm-bindgen = "0.2"
 wee_alloc = "0.4.5"
 
 [profile.release]
@@ -20,5 +18,3 @@ lto = "fat"
 opt-level = "z"
 panic = "abort"
 strip = true
-trim-paths = "all"
-rustflags = ["-Cdebuginfo=0", "-Zthreads=8"]

--- a/png_encode/src/lib.rs
+++ b/png_encode/src/lib.rs
@@ -1,52 +1,94 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
 use png::{BitDepth, ColorType, Encoder};
-use std::{collections::HashMap, io::Cursor};
 use wasm_bindgen::prelude::*;
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[wasm_bindgen]
-pub fn export_png(width: u32, height: u32, pixels: &[u8]) -> Result<Vec<u8>, String> {
+pub fn export_png(width: u32, height: u32, pixels: &[u8]) -> Result<Vec<u8>, u8> {
     let mut buffer = Vec::new();
 
     {
-        let cursor = Cursor::new(&mut buffer);
-        let (indexed_pixels, palette) = rgba_to_indexed(pixels)?;
+        let (indexed_pixels, palette, trns) = rgba_to_indexed(pixels)?;
 
-        let mut encoder = Encoder::new(cursor, width, height);
+        let mut encoder = Encoder::new(&mut buffer, width, height);
+
         encoder.set_color(ColorType::Indexed);
         encoder.set_depth(BitDepth::Eight);
-        encoder.set_palette(palette.clone());
 
-        let mut writer = encoder.write_header().unwrap();
+        encoder.set_palette(palette);
+        encoder.set_trns(trns);
 
-        writer.write_image_data(&indexed_pixels).unwrap();
+        let mut writer = encoder.write_header().map_err(|_| 1)?;
+
+        writer.write_image_data(&indexed_pixels).map_err(|_| 2)?;
     }
 
     Ok(buffer)
 }
 
-fn rgba_to_indexed(rgba: &[u8]) -> Result<(Vec<u8>, Vec<u8>), String> {
+const ALPHA_THRESHOLD: u8 = 154;
+
+fn rgba_to_indexed(rgba: &[u8]) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), u8> {
     let mut palette: Vec<[u8; 3]> = Vec::new();
-    let mut color_map: HashMap<[u8; 3], u8> = HashMap::new();
+    let mut alphas: Vec<u8> = Vec::new();
+
     let mut indexed_pixels = Vec::with_capacity(rgba.len() / 4);
 
-    for chunk in rgba.chunks(4) {
+    for chunk in rgba.chunks_exact(4) {
         let rgb = [chunk[0], chunk[1], chunk[2]];
+        let a = chunk[3];
 
-        if let Some(&idx) = color_map.get(&rgb) {
-            indexed_pixels.push(idx);
-        } else {
-            if palette.len() >= 256 {
-                return Err("Palette too big, max 256 colors".to_string());
-            }
-            let idx = palette.len() as u8;
-            palette.push(rgb);
-            color_map.insert(rgb, idx);
-            indexed_pixels.push(idx);
+        if a < ALPHA_THRESHOLD {
+            indexed_pixels.push(0);
+            continue;
         }
+
+        let mut found: Option<u8> = None;
+
+        for (i, p) in palette.iter().enumerate() {
+            let idx = i as u8 + 1;
+            if *p == rgb {
+                found = Some(idx);
+                break;
+            }
+        }
+
+        let idx = match found {
+            Some(i) => i,
+
+            None => {
+                if palette.len() >= 255 {
+                    return Err(3);
+                }
+
+                let i = palette.len() as u8 + 1;
+
+                palette.push(rgb);
+                alphas.push(255);
+
+                i
+            }
+        };
+
+        indexed_pixels.push(idx);
     }
 
-    let flat_palette: Vec<u8> = palette.iter().flat_map(|rgb| rgb.iter().copied()).collect();
-    Ok((indexed_pixels, flat_palette))
+    let mut flat_palette = Vec::with_capacity((palette.len() + 1) * 3);
+    let mut trns = Vec::with_capacity(palette.len() + 1);
+
+    flat_palette.extend_from_slice(&[0, 0, 0]);
+    trns.push(0);
+
+    for rgb in palette.iter() {
+        flat_palette.extend_from_slice(rgb);
+        trns.push(255);
+    }
+
+    Ok((indexed_pixels, flat_palette, trns))
 }


### PR DESCRIPTION
Closes #3 

Okay since i kinda broke it with the encoder :skull: i should be the one to fix it. The solution is kinda hacky, colored pixels are always fully transparent and pixels with an alpha under the threshold are fully transparent. if it works it works right.

also made the wasm bundle a tiny bit smaller by ditching std library, and some heap stuff like hashmaps and strings